### PR TITLE
Passing no params to ImageAdminField is fixed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ With **django-admin-easy** you can easily create this field with less lines:
         fields = ('sum_method', 'some_img', 'is_true')
 
         sum_method = easy.SimpleAdminField(lambda obj: '<b>%s</b>' % (obj.field1 + obj.field2 + obj.field3), 'Sum', 'field1', True)
-        some_img = easy.ImageAdminField('image', 'id')
+        some_img = easy.ImageAdminField('image')
         is_true = easy.BooleanAdminField('Positive', 'value')
 
 If you still prefer using a custom method, you can use our decorators, like this:

--- a/easy/admin/field.py
+++ b/easy/admin/field.py
@@ -168,7 +168,7 @@ class ImageAdminField(BaseAdminField):
 
     def __init__(self, attr, params=None, short_description=None, admin_order_field=None):
         self.attr = attr
-        self.params = params
+        self.params = params or {}
         super(ImageAdminField, self).__init__(short_description or attr, admin_order_field, True)
 
     def render(self, obj):


### PR DESCRIPTION
ImageAdminField fails to render when it is initialized with no params.