### PR TITLE
Add ManyToManyAdminField for use with ManyToManyField

### DIFF
--- a/easy/admin/field.py
+++ b/easy/admin/field.py
@@ -46,6 +46,9 @@ class SimpleAdminField(BaseAdminField):
 
         super(SimpleAdminField, self).__init__(short_description, admin_order_field, allow_tags)
 
+    def __name__(self):
+        return 'SimpleAdminField'
+
     def render(self, obj):
         return helper.call_or_get(obj, self.attr, self.default)
 

--- a/easy/tests.py
+++ b/easy/tests.py
@@ -18,7 +18,7 @@ from model_mommy import mommy
 import easy
 from easy.helper import Nothing
 from test_app.admin import PollAdmin
-from test_app.models import Question, Poll
+from test_app.models import Question, Poll, PollGroup
 
 
 class TestSimpleAdminField(test.TestCase):
@@ -121,6 +121,57 @@ class TestForeignKeyAdminField(test.TestCase):
             expected = u'<a href="/admin/test_app/poll/1/">1</a>'
         else:
             expected = u'<a href="/admin/test_app/poll/1/change/">1</a>'
+
+        self.assertEqual(expected, ret)
+        self.assertTrue(custom_field.allow_tags)
+
+
+class TestManyToManyAdminField(test.TestCase):
+    def test_foreignkey(self):
+        poll_group = mommy.make(
+            PollGroup,
+            name='Test Poll Group'
+        )
+
+        poll_one = mommy.make(Poll, name='Test Poll #1')
+        poll_two = mommy.make(Poll, name='Test Poll #2')
+        poll_group.add(poll_one)
+        poll_group.add(poll_two)
+
+        custom_field = easy.ManyToManyAdminField('polls')
+        ret = custom_field(poll_group)
+        if django.VERSION < (1, 9):
+            expected = u'<ul><li><a href="/admin/test_app/poll/%s/">Poll object</a></li>' % (poll_one.id, )
+            expected += u'<li><a href="/admin/test_app/poll/%s/">Poll object</a></li>' % (poll_two.id, )
+        elif django.VERSION < (2, 0):
+            expected = u'<ul><li><a href="/admin/test_app/poll/%s/change/">Poll object</a></li>' % (poll_one.id, )
+            expected += u'<li><a href="/admin/test_app/poll/%s/change/">Poll object</a></li>' % (poll_two.id, )
+        else:
+            expected = u'<ul><li><a href="/admin/test_app/poll/%s/change/">Poll object (1)</a></li>' % (poll_one.id, )
+            expected += u'<li><a href="/admin/test_app/poll/%s/change/">Poll object (1)</a></li>' % (poll_two.id, )
+
+        self.assertEqual(expected, ret)
+        self.assertTrue(custom_field.allow_tags)
+
+    def test_foreignkey_display(self):
+        poll_group = mommy.make(
+            PollGroup,
+            name='Test Poll Group'
+        )
+
+        poll_one = mommy.make(Poll, name='Test Poll #1')
+        poll_two = mommy.make(Poll, name='Test Poll #2')
+        poll_group.add(poll_one)
+        poll_group.add(poll_two)
+
+        custom_field = easy.ManyToManyAdminField('polls', 'name')
+        ret = custom_field(poll_group)
+        if django.VERSION < (1, 9):
+            expected = u'<ul><li><a href="/admin/test_app/poll/%s/">%s</a></li>' % (poll_one.id, poll_group.name, )
+            expected += u'<li><a href="/admin/test_app/poll/%s/">%s</a></li></ul>' % (poll_two.id, poll_group.name, )
+        else:
+            expected = u'<ul><li><a href="/admin/test_app/poll/%s/change/">%s</a></li>' % (poll_one.id, poll_group.name, )
+            expected += u'<li><a href="/admin/test_app/poll/%s/change/">%s</a></li></ul>' % (poll_two.id, poll_group.name, )
 
         self.assertEqual(expected, ret)
         self.assertTrue(custom_field.allow_tags)

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -6,6 +6,13 @@ class Poll(models.Model):
     name = models.CharField(max_length=200)
 
 
+class PollGroup(models.Model):
+    """Add this model to test the ManyToManyAdminField."""
+
+    name = models.CharField(max_length=200)
+    polls = models.ManyToManyField(Poll, related_name='poll_groups')
+
+
 class Question(models.Model):
     question_text = models.CharField(max_length=200)
     pub_date = models.DateTimeField('date published')


### PR DESCRIPTION
I've added a field to show the objects of a many to many field in a list. And I added a `__name__` method to `SimpleAdminField` because Django was complaining that `__name__` could not be found.